### PR TITLE
Ensure unique tag keys in product grid

### DIFF
--- a/src/components/ProductGridStep1.jsx
+++ b/src/components/ProductGridStep1.jsx
@@ -107,8 +107,8 @@ export default function ProductGridStep1() {
                                 <span className="Card-stock">{p.stock}</span>
                             </div>
                             <ul className="Card-tags">
-                                {p.tags.map((t, i) => (
-                                    <li className="Tag" key={i}>
+                                {Array.from(new Set(p.tags)).map((t) => (
+                                    <li className="Tag" key={t}>
                                         {t}
                                     </li>
                                 ))}


### PR DESCRIPTION
## Summary
- Deduplicate product tag lists and use tag text as React list key to prevent collisions

## Testing
- `npm test -- --watchAll=false` *(fails: useCart must be used within CartProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b161f71aa08330b2adfc4116297cc3