### PR TITLE
Reemplazar span por botón y mover estilos del carrito

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,6 +46,30 @@
   outline-offset: 2px;
 }
 
+.CartButton {
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+}
+
+.CartButton-badge {
+  position: absolute;
+  top: -4px;
+  right: -8px;
+  background: #e02424;
+  color: #fff;
+  border-radius: 50%;
+  padding: 2px 5px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/src/App.js
+++ b/src/App.js
@@ -24,41 +24,22 @@ export default function App() {
                     <a href="#inicio">Inicio</a> |{" "}
                     <a href="#productos">Productos</a> |{" "}
                     <a href="#contacto">Contacto</a> |{" "}
-                    <span
-                        role="button"
+                    <button
+                        type="button"
+                        className="CartButton"
                         aria-label="Abrir carrito"
-                        tabIndex={0}
                         onClick={() => setIsCartOpen(true)}
                         onKeyDown={(e) =>
                             (e.key === "Enter" || e.key === " ") && setIsCartOpen(true)
                         }
-                        style={{
-                            position: "relative",
-                            cursor: "pointer",
-                            display: "inline-flex",
-                            alignItems: "center",
-                        }}
                     >
-            <FaShoppingCart size={18} />
+                        <FaShoppingCart size={18} />
                         {itemsCount > 0 && (
-                            <span
-                                style={{
-                                    position: "absolute",
-                                    top: "-4px",
-                                    right: "-8px",
-                                    background: "#e02424",
-                                    color: "#fff",
-                                    borderRadius: "50%",
-                                    padding: "2px 5px",
-                                    fontSize: "10px",
-                                    fontWeight: 700,
-                                    lineHeight: 1,
-                                }}
-                            >
-                {itemsCount}
-              </span>
+                            <span className="CartButton-badge">
+                                {itemsCount}
+                            </span>
                         )}
-          </span>
+                    </button>
                 </nav>
 
                 <p>Bienvenido a nuestro catálogo de importaciones.</p>


### PR DESCRIPTION
## Summary
- reemplazar el contenedor del icono de carrito por un botón accesible
- mover estilos inline a clases CSS para el botón y el badge

## Testing
- `npm test -- --watchAll=false` *(falla: useCart must be used within CartProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b163c3c2fc833094bb81ed650b60ce