### PR TITLE
Mover estilos del badge del carrito a clase CSS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,9 +41,23 @@
   color: #61dafb;
   text-decoration: underline;
 }
-.App-nav a:focus-visible {
-  outline: 2px dashed #61dafb;
-  outline-offset: 2px;
+  .App-nav a:focus-visible {
+    outline: 2px dashed #61dafb;
+    outline-offset: 2px;
+  }
+
+/* Badge sobre el icono de carrito */
+.Cart-badge {
+  position: absolute;
+  top: -4px;
+  right: -8px;
+  background: #e02424;
+  color: #fff;
+  border-radius: 50%;
+  padding: 2px 5px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
 }
 
 @keyframes App-logo-spin {

--- a/src/App.js
+++ b/src/App.js
@@ -41,22 +41,9 @@ export default function App() {
                     >
             <FaShoppingCart size={18} />
                         {itemsCount > 0 && (
-                            <span
-                                style={{
-                                    position: "absolute",
-                                    top: "-4px",
-                                    right: "-8px",
-                                    background: "#e02424",
-                                    color: "#fff",
-                                    borderRadius: "50%",
-                                    padding: "2px 5px",
-                                    fontSize: "10px",
-                                    fontWeight: 700,
-                                    lineHeight: 1,
-                                }}
-                            >
-                {itemsCount}
-              </span>
+                            <span className="Cart-badge">
+                                {itemsCount}
+                            </span>
                         )}
           </span>
                 </nav>


### PR DESCRIPTION
## Summary
- Añade la clase `.Cart-badge` con los estilos del indicador del carrito
- Aplica `className="Cart-badge"` al elemento que muestra la cantidad y elimina los estilos inline

## Testing
- `CI=true npm test` *(falló: useCart must be used within CartProvider)*

------
https://chatgpt.com/codex/tasks/task_e_68b163c461ec8330955d3ad907222067