### PR TITLE
Add CartContext and CartDrawer tests

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { CartProvider } from './context/CartContext';
 
 test('renders learn react link', () => {
-  render(<App />);
+  render(
+    <CartProvider>
+      <App />
+    </CartProvider>
+  );
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/components/__tests__/CartDrawer.test.jsx
+++ b/src/components/__tests__/CartDrawer.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CartDrawer from '../CartDrawer';
+import { CartProvider, useCart } from '../../context/CartContext';
+
+function renderWithCart(ui) {
+  let cart;
+  function ContextGrabber() {
+    cart = useCart();
+    return null;
+  }
+  render(
+    <CartProvider>
+      <ContextGrabber />
+      {ui}
+    </CartProvider>
+  );
+  return cart;
+}
+
+describe('CartDrawer', () => {
+  test('renders items and total', () => {
+    const cart = renderWithCart(<CartDrawer isOpen onClose={() => {}} />);
+    act(() => {
+      cart.addItem({ id: 1, title: 'Item A', price: '10' });
+    });
+
+    expect(screen.getByText('Item A')).toBeInTheDocument();
+    expect(screen.getByText(/Total:/)).toHaveTextContent('$10');
+  });
+
+  test('removes item when remove button is clicked', async () => {
+    const cart = renderWithCart(<CartDrawer isOpen onClose={() => {}} />);
+    act(() => {
+      cart.addItem({ id: 1, title: 'Item A', price: '10' });
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Quitar/i }));
+    expect(screen.queryByText('Item A')).not.toBeInTheDocument();
+    expect(screen.getByText(/Aún no has agregado productos/)).toBeInTheDocument();
+  });
+
+  test('clears cart when clear button is clicked', async () => {
+    const cart = renderWithCart(<CartDrawer isOpen onClose={() => {}} />);
+    act(() => {
+      cart.addItem({ id: 1, title: 'Item A', price: '10' });
+      cart.addItem({ id: 2, title: 'Item B', price: '20' });
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Vaciar carrito/i }));
+    expect(screen.getByText(/Aún no has agregado productos/)).toBeInTheDocument();
+  });
+});
+

--- a/src/context/__tests__/CartContext.test.js
+++ b/src/context/__tests__/CartContext.test.js
@@ -1,0 +1,72 @@
+import { renderHook, act } from '@testing-library/react';
+import { CartProvider, useCart } from '../CartContext';
+
+describe('CartContext', () => {
+  const wrapper = ({ children }) => <CartProvider>{children}</CartProvider>;
+
+  test('addItem adds and increments quantity', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ id: 1, title: 'A', price: '10' });
+    });
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].qty).toBe(1);
+
+    act(() => {
+      result.current.addItem({ id: 1, title: 'A', price: '10' });
+    });
+    expect(result.current.items[0].qty).toBe(2);
+  });
+
+  test('removeItem removes item by id', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ id: 1, title: 'A', price: '10' });
+      result.current.addItem({ id: 2, title: 'B', price: '15' });
+    });
+
+    act(() => {
+      result.current.removeItem(1);
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe(2);
+  });
+
+  test('clearCart empties all items', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ id: 1, title: 'A', price: '10' });
+      result.current.addItem({ id: 2, title: 'B', price: '15' });
+      result.current.clearCart();
+    });
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  test('getCount returns total quantity', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ id: 1, title: 'A', price: '10' }, 2);
+      result.current.addItem({ id: 2, title: 'B', price: '15' }, 3);
+    });
+
+    expect(result.current.getCount()).toBe(5);
+  });
+
+  test('getTotal returns sum of item totals', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem({ id: 1, title: 'A', price: '$10' }, 2);
+      result.current.addItem({ id: 2, title: 'B', price: '15' }, 1);
+    });
+
+    expect(result.current.getTotal()).toBe(35);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test addItem, removeItem, clearCart, getCount and getTotal in CartContext
- add CartDrawer rendering and user interaction tests
- wrap App test with CartProvider

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b163c643248330998f3710f115c950