### PR TITLE
feat: persist cart in localStorage

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { CartProvider } from './context/CartContext';
 
 test('renders learn react link', () => {
-  render(<App />);
+  render(
+    <CartProvider>
+      <App />
+    </CartProvider>
+  );
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/context/CartContext.js
+++ b/src/context/CartContext.js
@@ -1,9 +1,24 @@
-import { createContext, useContext, useMemo, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
 const CartContext = createContext(null);
 
 export function CartProvider({ children }) {
     const [items, setItems] = useState([]);
+
+    useEffect(() => {
+        const stored = localStorage.getItem("cartItems");
+        if (stored) {
+            try {
+                setItems(JSON.parse(stored));
+            } catch {
+                // ignore malformed data
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        localStorage.setItem("cartItems", JSON.stringify(items));
+    }, [items]);
 
     const addItem = (product, qty = 1) => {
         setItems(prev => {

--- a/src/context/CartContext.test.js
+++ b/src/context/CartContext.test.js
@@ -1,0 +1,40 @@
+import { act, render } from "@testing-library/react";
+import { CartProvider, useCart } from "./CartContext";
+
+const TestComponent = ({ onReady }) => {
+    const cart = useCart();
+    onReady?.(cart);
+    return null;
+};
+
+test("loads items from localStorage on init", () => {
+    const stored = [{ id: 1, price: "10", qty: 2 }];
+    localStorage.setItem("cartItems", JSON.stringify(stored));
+
+    let items;
+    render(
+        <CartProvider>
+            <TestComponent onReady={(cart) => (items = cart.items)} />
+        </CartProvider>
+    );
+
+    expect(items).toEqual(stored);
+});
+
+test("syncs items to localStorage when changed", () => {
+    localStorage.clear();
+    let api;
+    render(
+        <CartProvider>
+            <TestComponent onReady={(cart) => (api = cart)} />
+        </CartProvider>
+    );
+
+    act(() => {
+        api.addItem({ id: 2, price: "5" }, 1);
+    });
+
+    const stored = JSON.parse(localStorage.getItem("cartItems"));
+    expect(stored).toEqual([{ id: 2, price: "5", qty: 1 }]);
+});
+


### PR DESCRIPTION
## Summary
- load cart items from localStorage on mount
- sync cart changes to localStorage
- add tests for cart persistence and wrap App tests with provider

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b163c78df883309f86193537f27ba4