### PR TITLE
Wrap tests with CartProvider

### DIFF
--- a/src/components/__tests__/CartDrawer.test.jsx
+++ b/src/components/__tests__/CartDrawer.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import CartDrawer from "../CartDrawer";
+import { CartProvider } from "../../context/CartContext";
+
+test("shows empty cart message", () => {
+  render(
+    <CartProvider>
+      <CartDrawer isOpen onClose={() => {}} />
+    </CartProvider>
+  );
+  expect(screen.getByText(/Aún no has agregado productos/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add CartDrawer test wrapped with CartProvider to validate empty cart rendering

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b172aef7c08330950a1a34e7922bb1